### PR TITLE
Add support for private and presence channels

### DIFF
--- a/Authenticator/ChannelAuthenticatorInterface.php
+++ b/Authenticator/ChannelAuthenticatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ *
+ */
+
+namespace Lopi\Bundle\PusherBundle\Authenticator;
+
+/**
+ * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
+ */ 
+interface ChannelAuthenticatorInterface
+{
+
+    /**
+     * @param string $socketId
+     * @param string $channelName
+     * @return bool
+     */
+    public function authenticate($socketId, $channelName);
+}

--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ *
+ */
+
+namespace Lopi\Bundle\PusherBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
+ */
+class AuthController extends ContainerAware
+{
+
+    /**
+     * Implement http://pusher.com/docs/authenticating_users
+     * and       http://pusher.com/docs/auth_signatures
+     *
+     * @param Request $request
+     */
+    public function authAction(Request $request)
+    {
+        $socketId = $request->get('socket_id');
+        $channelName = $request->get('channel_name');
+
+        if (!$this->container->get('lopi_pusher.authenticator')->authenticate($socketId, $channelName)) {
+            throw new AccessDeniedException('Request authentication denied');
+        }
+
+        $secret = $this->container->getParameter('lopi_pusher.secret');
+        $key = $this->container->getParameter('lopi_pusher.key');
+
+        $code = hash_hmac('sha256', $socketId.":".$channelName, $secret);
+        $auth = $key.":".$code;
+
+        return new Response(json_encode(array('auth' => $auth)), 200, array('Content-Type' => 'application/json'));
+    }
+
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('encrypted')
                     ->defaultValue(false)
                     ->end()
+                ->scalarNode('auth_service_id')
+                    ->defaultNull()
+                    ->end()
             ->end()
         ;
 

--- a/DependencyInjection/LopiPusherExtension.php
+++ b/DependencyInjection/LopiPusherExtension.php
@@ -39,6 +39,10 @@ class LopiPusherExtension extends Extension
         if (isset($config['encrypted'])) {
             $container->setParameter('lopi_pusher.encrypted', $config['encrypted']);
         }
+
+        if (isset($config['auth_service_id'])) {
+            $container->setAlias('lopi_pusher.authenticator', $config['auth_service_id']);
+        }
 		
         $loader->load('services.xml');
     }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,0 +1,5 @@
+lopi_pusher_bundle_auth:
+    pattern:       /
+    defaults:     { _controller: LopiPusherBundle:Auth:auth }
+    requirements:
+        _method:  POST

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -91,9 +91,49 @@ lopi_pusher:
     app_id: xxx
 	key: xxx
 	secret: xxx
+	auth_service_id: xxx # optional if you want to use private or presence channels
 ```
 
 All parameters must correspond to http://app.pusherapp.com/apps/xxxx/api_access in the first block.
+
+### Step 4: Private and Presence channel authentication (optional)
+
+If you'd like to use private or presence, you need to add an authorization service.  First, create an authorization
+service that implements `Lopi\Bundle\PusherBundle\Authenticator\ChannelAuthenticatorInterface` and include it's
+service id in the lopi_pusher `auth_service_id` configuration parameter.
+
+``` php
+<?php
+// My/Bundle/AcmeBundle/Pusher/ChannelAuthenticator
+
+namespace My\Bundle\AcmeBundle\Pusher
+
+use Lopi\Bundle\PusherBundle\Authenticator\ChannelAuthenticatorInterface
+
+class ChannelAuthenticator implements ChannelAuthenticationInterface
+{
+    public function authenticate($socketId, $channelName)
+    {
+        // logic here
+
+        return true;
+    }
+}
+```
+
+Additionally, enable the route by adding the following to your `app\config\routing.yml` configuration:
+
+    # app\config\routing.yml
+    lopi_pusher:
+        resource: "@LopiPusherBundle/Resources/config/routing.yml"
+        prefix:   /pusher/auth
+
+In some symfony configurations, you may need to manually specify the channel_auth_endpoint: (not required in most setups)
+
+    <script type="text/javascript">
+        Pusher.channel_auth_endpoint = "{{ path('lopi_pusher_bundle_auth') }}";
+    </script>
+
 
 ## Use Pusher
 
@@ -106,7 +146,7 @@ $pusher = $this->container->get('lopi_pusher.pusher');
 $pusher->trigger('channel name', 'event name', 'message');
 ```
 
-If you want use the sockect id, 
+If you want use the socket id,
 
 ``` php
 <?php

--- a/Tests/DependencyInjection/LopiPusherExtensionTest.php
+++ b/Tests/DependencyInjection/LopiPusherExtensionTest.php
@@ -15,7 +15,8 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         $configs = array('lopi_pusher' => array(
 			'app_id' => 'app_id',
 			'key' => 'key',
-			'secret' => 'secret'
+			'secret' => 'secret',
+            'auth_service_id' => 'acme_service_id'
 			));
 		$extension = new LopiPusherExtension();
 		$extension->load($configs, $container);
@@ -28,6 +29,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue(is_string($container->getParameter('lopi_pusher.auth.version')));
 		$this->assertTrue("1.0" === $container->getParameter('lopi_pusher.auth.version'));
 		$this->assertFalse($container->getParameter('lopi_pusher.encrypted'));
+        $this->assertEquals('acme_service_id', $container->getAlias('lopi_pusher.authenticator'));
     }
 	
 	public function testLoadWithConfig()
@@ -38,6 +40,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 			'key' => 'key',
 			'secret' => 'secret',
 			'encrypted' => true,
+            'auth_service_id' => 'acme_service_id'
 			));
 		$extension = new LopiPusherExtension();
 		$extension->load($configs, $container);
@@ -50,5 +53,6 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 		$this->assertTrue(is_string($container->getParameter('lopi_pusher.auth.version')));
 		$this->assertTrue("1.0" === $container->getParameter('lopi_pusher.auth.version'));
 		$this->assertTrue($container->getParameter('lopi_pusher.encrypted'));
+        $this->assertEquals('acme_service_id', $container->getAlias('lopi_pusher.authenticator'));
     }
 }


### PR DESCRIPTION
Adds a simple controller for supporting the authentication endpoint.

Users implementing this functionality should create a service that implements an interface that LopiPusherBundle provides.

References:  http://pusher.com/docs/authenticating_users and http://pusher.com/docs/auth_signatures

Instructions are included in the `Resources\doc\index.md`
