### PR TITLE
Fix order of service arguments to match Pusher class

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,9 +7,9 @@
     <services>
 
         <service id="lopi_pusher.pusher" class="Pusher">
-            <argument>%lopi_pusher.app.id%</argument>
             <argument>%lopi_pusher.key%</argument>
             <argument>%lopi_pusher.secret%</argument>
+            <argument>%lopi_pusher.app.id%</argument>
             <argument>%lopi_pusher.debug%</argument>
             <argument>%lopi_pusher.host%</argument>
             <argument>%lopi_pusher.port%</argument>


### PR DESCRIPTION
The arguments were being passed to the Pusher class in an incorrect order, causing it to return a 401 auth error.
