### PR TITLE
Upgrade pusher library to >=2.2.1 which fixes a security exploit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "pusher/pusher-php-server": "~2.1"
+        "pusher/pusher-php-server": ">=2.2.1"
     },
     "require-dev": {
         "symfony/config": "~2.3",


### PR DESCRIPTION
Pusher have recently disclosed a security vulnerability where malformed parameters could be sent to a auth endpoint which would trick it into signing a string to authenticate to a different private channel. 

They have fixed the issue on their end but recommend that server libraries be updated to use the latest version which has strong validation of the input they receive.

This library updated does not introduce any breaking changes to the PusherBundle.