### PR TITLE
Created a configurable logger

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('key')->isRequired()->end()
                 ->scalarNode('secret')->isRequired()->end()
                 ->booleanNode('debug')->defaultValue(false)->end()
+                ->booleanNode('log')->defaultValue(false)->end()
                 ->scalarNode('host')->defaultValue('http://api.pusherapp.com')->end()
                 ->scalarNode('port')->defaultValue('80')->end()
                 ->scalarNode('timeout')->defaultValue('30')->end()

--- a/DependencyInjection/LopiPusherExtension.php
+++ b/DependencyInjection/LopiPusherExtension.php
@@ -5,6 +5,7 @@ namespace Lopi\Bundle\PusherBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -35,6 +36,10 @@ class LopiPusherExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        if (true === $config['log']) {
+            $container->getDefinition('lopi_pusher.pusher')->addMethodCall('set_logger', array(new Reference('lopi_pusher.logger')));
+        }
     }
 
     /**

--- a/Logger/DebugLogger.php
+++ b/Logger/DebugLogger.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Lopi\Bundle\PusherBundle\Logger;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * DebugLogger
+ *
+ * @author Robin van der Vleuten <robin@seigyo.io>
+ */
+class DebugLogger
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($message)
+    {
+        $this->logger->debug($message);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This is the default configuration in yml:
 
         # Default configuration
         debug: false # true if you want use the debug of all requests
+        log: false # true if you want to log the Pusher calls
         host: http://api.pusherapp.com
         port: 80
         timeout: 30

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,5 +16,10 @@
             <argument>%lopi_pusher.timeout%</argument>
         </service>
 
+        <service id="lopi_pusher.logger" class="Lopi\Bundle\PusherBundle\Logger\DebugLogger" public="false">
+            <tag name="monolog.logger" channel="pusher" />
+            <argument type="service" id="logger" />
+        </service>
+
     </services>
 </container>

--- a/Tests/DependencyInjection/LopiPusherExtensionTest.php
+++ b/Tests/DependencyInjection/LopiPusherExtensionTest.php
@@ -5,6 +5,7 @@ namespace Lopi\Bundle\PusherBundle\Tests\DependencyInjection;
 use Lopi\Bundle\PusherBundle\DependencyInjection\LopiPusherExtension;
 use Pusher;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * PusherTest
@@ -37,6 +38,8 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('80', $container->getParameter('lopi_pusher.port'));
         $this->assertEquals('30', $container->getParameter('lopi_pusher.timeout'));
         $this->assertEquals('acme_service_id', (string) $container->getAlias('lopi_pusher.authenticator'));
+
+        $this->assertFalse($container->getDefinition('lopi_pusher.pusher')->hasMethodCall('set_logger'));
     }
 
     /**
@@ -45,11 +48,14 @@ class PusherTest extends \PHPUnit_Framework_TestCase
     public function testLoadWithConfig()
     {
         $container = new ContainerBuilder();
+        $container->setDefinition('logger', new Definition('Symfony\Bridge\Monolog\Logger', array('pusher')));
+
         $configs = array('lopi_pusher' => array(
             'app_id' => 'app_id',
             'key' => 'key',
             'secret' => 'secret',
             'debug' => true,
+            'log' => true,
             'host' => 'https://api.pusherapp.com',
             'port' => '443',
             'timeout' => '60',
@@ -67,5 +73,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('443', $container->getParameter('lopi_pusher.port'));
         $this->assertEquals('60', $container->getParameter('lopi_pusher.timeout'));
         $this->assertEquals('acme_service_id', (string) $container->getAlias('lopi_pusher.authenticator'));
+
+        $this->assertTrue($container->getDefinition('lopi_pusher.pusher')->hasMethodCall('set_logger'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require-dev": {
         "symfony/config": "~2.3",
         "symfony/dependency-injection": "~2.3",
-        "symfony/http-kernel": "~2.3"
+        "symfony/http-kernel": "~2.3",
+        "symfony/monolog-bridge": "~2.3"
     },
     "autoload": {
         "psr-0": { "Lopi\\Bundle\\PusherBundle": "" }


### PR DESCRIPTION
Hi there,

The underlaying Pusher library isn't erroring very much when they occur, so logging is essential here. I've added a configurable logger that logs the messages to the _pusher_ channel.

Cheers,
Robin