### PR TITLE
DEPRECATED - The "pattern" option Replaced By path

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="lopi_pusher_bundle_auth" pattern="/auth" methods="POST">
+    <route id="lopi_pusher_bundle_auth" path="/auth" methods="POST">
         <default key="_controller">LopiPusherBundle:Auth:auth</default>
     </route>
 


### PR DESCRIPTION
DEPRECATED - The "pattern" option is deprecated since version 2.2 and will be removed in 3.0. Fixed the issue with adding path