### PR TITLE
Adds url configuration and fixes deprecated construction

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,13 +24,28 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('lopi_pusher', 'array');
 
         $rootNode
+            ->validate()
+                ->ifTrue(
+                    function($data) {
+                        return empty($data['url'])
+                            && (
+                                empty($data['app_id'])
+                                || empty($data['key'])
+                                || empty($data['secret'])
+                            );
+                    }
+                )
+                ->thenInvalid('Either url or app_id, key and secret needs to be set.')
+            ->end()
             ->children()
-                ->scalarNode('app_id')->isRequired()->end()
-                ->scalarNode('key')->isRequired()->end()
-                ->scalarNode('secret')->isRequired()->end()
+                ->scalarNode('url')->end()
+                ->scalarNode('app_id')->end()
+                ->scalarNode('key')->end()
+                ->scalarNode('secret')->end()
                 ->scalarNode('cluster')->defaultValue('us-east-1')->end()
                 ->booleanNode('debug')->defaultValue(false)->end()
-                ->scalarNode('host')->defaultValue('http://api.pusherapp.com')->end()
+                ->scalarNode('scheme')->defaultValue('http')->end()
+                ->scalarNode('host')->defaultValue('api.pusherapp.com')->end()
                 ->scalarNode('port')->defaultValue('80')->end()
                 ->scalarNode('timeout')->defaultValue('30')->end()
                 ->scalarNode('auth_service_id')->defaultNull()->end()

--- a/DependencyInjection/LopiPusherExtension.php
+++ b/DependencyInjection/LopiPusherExtension.php
@@ -21,33 +21,7 @@ class LopiPusherExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (!empty($config['url'])) {
-            $config['app_id'] = substr(parse_url($config['url'], PHP_URL_PATH), 6);
-            $config['key'] = parse_url($config['url'], PHP_URL_USER);
-            $config['secret'] = parse_url($config['url'], PHP_URL_PASS);
-            $config['scheme'] = parse_url($config['url'], PHP_URL_SCHEME);
-            $config['host'] = parse_url($config['url'], PHP_URL_HOST);
-            $config['port'] = parse_url($config['url'], PHP_URL_PORT) ?? $config['port'];
-        }
-
-        // For backwards compatibility with deprecated host argument
-        if (preg_match('(^(https?://))', $config['host'], $matches)) {
-            $config['scheme'] = substr($matches[0], 0, -3);
-            $config['host'] = substr($config['host'], strlen($matches[0]));
-        }
-
-        $options = [
-            'host' => $config['host'],
-            'port' => $config['port'],
-            'timeout' => $config['timeout'],
-            'cluster' => $config['cluster'],
-            'debug' => $config['debug'],
-        ];
-
-        $container->setParameter('lopi_pusher.app.id', $config['app_id']);
-        $container->setParameter('lopi_pusher.key', $config['key']);
-        $container->setParameter('lopi_pusher.secret', $config['secret']);
-        $container->setParameter('lopi_pusher.options', $options);
+        $container->setParameter('lopi_pusher.config', $config);
 
         if (null !== $config['auth_service_id']) {
             $container->setAlias('lopi_pusher.authenticator', $config['auth_service_id']);

--- a/DependencyInjection/PusherFactory.php
+++ b/DependencyInjection/PusherFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Lopi\Bundle\PusherBundle\DependencyInjection;
+
+use Pusher;
+
+class PusherFactory
+{
+    public static function create(array $config)
+    {
+        if (!empty($config['url'])) {
+            $config['app_id'] = substr(parse_url($config['url'], PHP_URL_PATH), 6);
+            $config['key'] = parse_url($config['url'], PHP_URL_USER);
+            $config['secret'] = parse_url($config['url'], PHP_URL_PASS);
+            $config['scheme'] = parse_url($config['url'], PHP_URL_SCHEME);
+            $config['host'] = parse_url($config['url'], PHP_URL_HOST);
+            $config['port'] = parse_url($config['url'], PHP_URL_PORT) ?? $config['port'];
+        }
+
+        // For backwards compatibility with deprecated host argument
+        if (preg_match('(^(https?://))', $config['host'], $matches)) {
+            $config['scheme'] = substr($matches[0], 0, -3);
+            $config['host'] = substr($config['host'], strlen($matches[0]));
+        }
+
+        return new Pusher(
+            $config['key'],
+            $config['secret'],
+            $config['app_id'],
+            [
+                'scheme' => $config['scheme'],
+                'host' => $config['host'],
+                'port' => $config['port'],
+                'timeout' => $config['timeout'],
+                'cluster' => $config['cluster'],
+                'debug' => $config['debug'],
+            ]
+        );
+    }
+}

--- a/DependencyInjection/PusherFactory.php
+++ b/DependencyInjection/PusherFactory.php
@@ -14,7 +14,7 @@ class PusherFactory
             $config['secret'] = parse_url($config['url'], PHP_URL_PASS);
             $config['scheme'] = parse_url($config['url'], PHP_URL_SCHEME);
             $config['host'] = parse_url($config['url'], PHP_URL_HOST);
-            $config['port'] = parse_url($config['url'], PHP_URL_PORT) ?? $config['port'];
+            $config['port'] = parse_url($config['url'], PHP_URL_PORT) ?: $config['port'];
         }
 
         // For backwards compatibility with deprecated host argument

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,9 +11,6 @@
             <argument>%lopi_pusher.secret%</argument>
             <argument>%lopi_pusher.app.id%</argument>
             <argument>%lopi_pusher.options%</argument>
-            <argument>%lopi_pusher.host%</argument>
-            <argument>%lopi_pusher.port%</argument>
-            <argument>%lopi_pusher.timeout%</argument>
         </service>
 
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,10 +7,8 @@
     <services>
 
         <service id="lopi_pusher.pusher" class="Pusher">
-            <argument>%lopi_pusher.key%</argument>
-            <argument>%lopi_pusher.secret%</argument>
-            <argument>%lopi_pusher.app.id%</argument>
-            <argument>%lopi_pusher.options%</argument>
+            <factory class="Lopi\Bundle\PusherBundle\DependencyInjection\PusherFactory" method="create" />
+            <argument>%lopi_pusher.config%</argument>
         </service>
 
     </services>

--- a/Tests/DependencyInjection/LopiPusherExtensionTest.php
+++ b/Tests/DependencyInjection/LopiPusherExtensionTest.php
@@ -18,24 +18,27 @@ class PusherTest extends \PHPUnit_Framework_TestCase
     public function testLoad()
     {
         $container = new ContainerBuilder();
-        $configs = array('lopi_pusher' => array(
-            'app_id' => 'app_id',
-            'key' => 'key',
-            'secret' => 'secret',
-            'auth_service_id' => 'acme_service_id'
-            ));
+        $configs = [
+            'lopi_pusher' => [
+                'app_id' => 'app_id',
+                'key' => 'key',
+                'secret' => 'secret',
+                'auth_service_id' => 'acme_service_id',
+            ],
+        ];
         $extension = new LopiPusherExtension();
         $extension->load($configs, $container);
 
         $this->assertInstanceOf('Pusher', $container->get('lopi_pusher.pusher'));
-        $this->assertEquals('app_id', $container->getParameter('lopi_pusher.app.id'));
-        $this->assertEquals('key', $container->getParameter('lopi_pusher.key'));
-        $this->assertEquals('secret', $container->getParameter('lopi_pusher.secret'));
-        $this->assertEquals('us-east-1', $container->getParameter('lopi_pusher.options')['cluster']);
-        $this->assertFalse($container->getParameter('lopi_pusher.options')['debug']);
-        $this->assertEquals('http://api.pusherapp.com', $container->getParameter('lopi_pusher.host'));
-        $this->assertEquals('80', $container->getParameter('lopi_pusher.port'));
-        $this->assertEquals('30', $container->getParameter('lopi_pusher.timeout'));
+        $this->assertEquals('app_id', $container->getParameter('lopi_pusher.config')['app_id']);
+        $this->assertEquals('key', $container->getParameter('lopi_pusher.config')['key']);
+        $this->assertEquals('secret', $container->getParameter('lopi_pusher.config')['secret']);
+        $this->assertEquals('acme_service_id', $container->getParameter('lopi_pusher.config')['auth_service_id']);
+        $this->assertFalse($container->getParameter('lopi_pusher.config')['debug']);
+        $this->assertEquals('http', $container->getParameter('lopi_pusher.config')['scheme']);
+        $this->assertEquals('api.pusherapp.com', $container->getParameter('lopi_pusher.config')['host']);
+        $this->assertEquals('80', $container->getParameter('lopi_pusher.config')['port']);
+        $this->assertEquals('30', $container->getParameter('lopi_pusher.config')['timeout']);
         $this->assertEquals('acme_service_id', (string) $container->getAlias('lopi_pusher.authenticator'));
     }
 
@@ -45,29 +48,31 @@ class PusherTest extends \PHPUnit_Framework_TestCase
     public function testLoadWithConfig()
     {
         $container = new ContainerBuilder();
-        $configs = array('lopi_pusher' => array(
-            'app_id' => 'app_id',
-            'key' => 'key',
-            'secret' => 'secret',
-            'cluster' => 'cluster',
-            'debug' => true,
-            'host' => 'https://api.pusherapp.com',
-            'port' => '443',
-            'timeout' => '60',
-            'auth_service_id' => 'acme_service_id'
-            ));
+        $configs = [
+            'lopi_pusher' => [
+                'url' => 'http://key:secret@api-eu.pusher.com/apps/app_id',
+                'cluster' => 'cluster',
+                'debug' => true,
+                'port' => '443',
+                'timeout' => '60',
+                'auth_service_id' => 'acme_service_id',
+            ],
+        ];
         $extension = new LopiPusherExtension();
         $extension->load($configs, $container);
 
-        $this->assertInstanceOf('Pusher', $container->get('lopi_pusher.pusher'));
-        $this->assertEquals('app_id', $container->getParameter('lopi_pusher.app.id'));
-        $this->assertEquals('key', $container->getParameter('lopi_pusher.key'));
-        $this->assertEquals('secret', $container->getParameter('lopi_pusher.secret'));
-        $this->assertEquals('cluster', $container->getParameter('lopi_pusher.options')['cluster']);
-        $this->assertTrue($container->getParameter('lopi_pusher.options')['debug']);
-        $this->assertEquals('https://api.pusherapp.com', $container->getParameter('lopi_pusher.host'));
-        $this->assertEquals('443', $container->getParameter('lopi_pusher.port'));
-        $this->assertEquals('60', $container->getParameter('lopi_pusher.timeout'));
+        $pusher = $container->get('lopi_pusher.pusher');
+        $pusherSettings = $pusher->getSettings();
+
+        $this->assertInstanceOf('Pusher', $pusher);
+        $this->assertEquals('app_id', $pusherSettings['app_id']);
+        $this->assertEquals('key', $pusherSettings['auth_key']);
+        $this->assertEquals('secret', $pusherSettings['secret']);
+        $this->assertEquals('cluster', $container->getParameter('lopi_pusher.config')['cluster']);
+        $this->assertTrue($pusherSettings['debug']);
+        $this->assertEquals('api-eu.pusher.com', $pusherSettings['host']);
+        $this->assertEquals('443', $pusherSettings['port']);
+        $this->assertEquals('60', $pusherSettings['timeout']);
         $this->assertEquals('acme_service_id', (string) $container->getAlias('lopi_pusher.authenticator'));
     }
 }


### PR DESCRIPTION
We needed a url configuration for Heroku eg. `http://<key>:<secret>@api-eu.pusher.com/apps/<app-id>`, thought others would benefit from this as well.