### PR TITLE
Adds Twig extension for global pusher key variable

### DIFF
--- a/DependencyInjection/PusherFactory.php
+++ b/DependencyInjection/PusherFactory.php
@@ -2,7 +2,7 @@
 
 namespace Lopi\Bundle\PusherBundle\DependencyInjection;
 
-use Pusher;
+use Pusher\Pusher;
 
 class PusherFactory
 {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,5 +11,10 @@
             <argument>%lopi_pusher.config%</argument>
         </service>
 
+        <service id="lopi_pusher.twig_extension" class="Lopi\Bundle\PusherBundle\Twig\PusherExtension" public="false">
+            <argument type="service" id="lopi_pusher.pusher"></argument>
+            <tag name="twig.extension" />
+        </service>
+
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="lopi_pusher.pusher" class="Pusher">
+        <service id="lopi_pusher.pusher" class="Pusher\Pusher">
             <factory class="Lopi\Bundle\PusherBundle\DependencyInjection\PusherFactory" method="create" />
             <argument>%lopi_pusher.config%</argument>
         </service>

--- a/Tests/DependencyInjection/LopiPusherExtensionTest.php
+++ b/Tests/DependencyInjection/LopiPusherExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Lopi\Bundle\PusherBundle\Tests\DependencyInjection;
 
 use Lopi\Bundle\PusherBundle\DependencyInjection\LopiPusherExtension;
+use Pusher\Pusher;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -29,7 +30,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         $extension = new LopiPusherExtension();
         $extension->load($configs, $container);
 
-        $this->assertInstanceOf('Pusher', $container->get('lopi_pusher.pusher'));
+        $this->assertInstanceOf(Pusher::class, $container->get('lopi_pusher.pusher'));
         $this->assertEquals('app_id', $container->getParameter('lopi_pusher.config')['app_id']);
         $this->assertEquals('key', $container->getParameter('lopi_pusher.config')['key']);
         $this->assertEquals('secret', $container->getParameter('lopi_pusher.config')['secret']);
@@ -64,7 +65,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         $pusher = $container->get('lopi_pusher.pusher');
         $pusherSettings = $pusher->getSettings();
 
-        $this->assertInstanceOf('Pusher', $pusher);
+        $this->assertInstanceOf(Pusher::class, $pusher);
         $this->assertEquals('app_id', $pusherSettings['app_id']);
         $this->assertEquals('key', $pusherSettings['auth_key']);
         $this->assertEquals('secret', $pusherSettings['secret']);

--- a/Twig/PusherExtension.php
+++ b/Twig/PusherExtension.php
@@ -1,13 +1,14 @@
 <?php
-declare(strict_types=1);
 
 namespace Lopi\Bundle\PusherBundle\Twig;
+
+use Pusher\Pusher;
 
 class PusherExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     private $pusher;
 
-    public function __construct(\Pusher $pusher)
+    public function __construct(Pusher $pusher)
     {
         $this->pusher = $pusher;
     }

--- a/Twig/PusherExtension.php
+++ b/Twig/PusherExtension.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Lopi\Bundle\PusherBundle\Twig;
+
+class PusherExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+{
+    private $pusher;
+
+    public function __construct(\Pusher $pusher)
+    {
+        $this->pusher = $pusher;
+    }
+
+    public function getGlobals()
+    {
+        return [
+            'pusher_key' => $this->pusher->getSettings()['auth_key'],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "pusher/pusher-php-server": ">=2.2.1"
+        "pusher/pusher-php-server": "^3.0"
     },
     "require-dev": {
         "symfony/config": "~2.7",


### PR DESCRIPTION
We needed to use this in our javascripts, thought it might be useful.
This is dependant on #50 to make the tests pass.