### PR TITLE
Prevent installing major changes of pusher-php-server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.6",
-        "pusher/pusher-php-server": ">=2.2.1"
+        "pusher/pusher-php-server": "^2.2.1"
     },
     "require-dev": {
         "symfony/config": "~2.7",


### PR DESCRIPTION
Fix #48

This PR prevent installing major version 3.x of `pusher/pusher-php-server` which has BC breaks.

This solution has no BC and should be merged before #50