### PR TITLE
Make alias public to work on SF4+

### DIFF
--- a/DependencyInjection/LopiPusherExtension.php
+++ b/DependencyInjection/LopiPusherExtension.php
@@ -29,7 +29,7 @@ class LopiPusherExtension extends Extension
         $container->setParameter('lopi_pusher.config', $config);
 
         if (null !== $config['auth_service_id']) {
-            $container->setAlias('lopi_pusher.authenticator', $config['auth_service_id']);
+            $container->setAlias('lopi_pusher.authenticator', $config['auth_service_id'])->setPublic(true);
         }
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));


### PR DESCRIPTION
Services in SF4+ are now private by default. To make the bundle work in SF4+ we have to set the alias to public. Maybe for further versions it would be better to inject the service to the controller instead of accessing it through the container.