### PR TITLE
Bumped pusher/pusher-php-server version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - hhvm
@@ -10,8 +9,6 @@ matrix:
     allow_failures:
         - php: hhvm
     include:
-        - php: 7.1
-          env: SYMFONY_VERSION=4.2.*
         - php: 7.2
           env: SYMFONY_VERSION=4.2.*
         - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "pusher/pusher-php-server": "^3.0",
+        "pusher/pusher-php-server": "^4.0",
         "twig/twig": "~2.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/laupiFrpar/LopiPusherBundle"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "pusher/pusher-php-server": "^4.0",
         "twig/twig": "~2.7"
     },


### PR DESCRIPTION
Adds support for PHP 7.4 since `pusher/pusher-php-server` required `PHP >=5.4 <7.4`. The update should be fully compatible. Here's the diff of the source from 3.4.1 to the current master https://github.com/pusher/pusher-http-php/compare/v3.4.1...master#diff-9a29448d10ca22b8348857ca96a1cb57

I had to remove `PHP 7.1` from the supported versions because of the phpunit version required by pusher/pusher-http-php. (PHP 7.1 reached EOL two weeks ago)