### PR TITLE
Make Twig dependency optional for use in API's

### DIFF
--- a/DependencyInjection/LopiPusherExtension.php
+++ b/DependencyInjection/LopiPusherExtension.php
@@ -11,6 +11,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extension\AbstractExtension;
 
 /**
  * LopiPusherExtension
@@ -34,6 +35,10 @@ class LopiPusherExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        if (class_exists(AbstractExtension::class)) {
+            $loader->load('twig.xml');
+        }
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,10 +11,5 @@
             <argument>%lopi_pusher.config%</argument>
         </service>
 
-        <service id="lopi_pusher.twig_extension" class="Lopi\Bundle\PusherBundle\Twig\PusherExtension" public="false">
-            <argument type="service" id="lopi_pusher.pusher"></argument>
-            <tag name="twig.extension" />
-        </service>
-
     </services>
 </container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="lopi_pusher.twig_extension" class="Lopi\Bundle\PusherBundle\Twig\PusherExtension" public="false">
+            <argument type="service" id="lopi_pusher.pusher"/>
+            <tag name="twig.extension" />
+        </service>
+
+    </services>
+</container>

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,21 @@
     },
     "require": {
         "php": ">=7.2",
-        "pusher/pusher-php-server": "^4.0",
-        "twig/twig": "~2.7|~3.0"
+        "pusher/pusher-php-server": "^4.0"
     },
     "require-dev": {
         "symfony/config": "~3.4",
         "symfony/dependency-injection": "~3.4",
         "symfony/http-kernel": "~3.4",
+        "twig/twig": "~2.7|~3.0",
         "phpunit/phpunit": "7.*"
     },
     "autoload": {
         "psr-4": {
             "Lopi\\Bundle\\PusherBundle\\": ""
         }
+    },
+    "conflict": {
+        "twig/twig": "<2.7"
     }
 }


### PR DESCRIPTION
Small change to remove `twig/twig` from required dependency. It's not necessary to have `twig/twig` installed on API project for example. :)

closes #65 