### PR TITLE
Fixed AuthController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_install:
     - find ~/.phpenv -name xdebug.ini -delete
     - composer self-update
-    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-main
     - composer update --prefer-source
 
 install:

--- a/src/DependencyInjection/LopiPusherExtension.php
+++ b/src/DependencyInjection/LopiPusherExtension.php
@@ -7,6 +7,7 @@
 
 namespace Lopi\Bundle\PusherBundle\DependencyInjection;
 
+use Lopi\Bundle\PusherBundle\Controller\AuthController;
 use Pusher\Pusher;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -35,9 +36,9 @@ class LopiPusherExtension extends Extension
         $pusherConfigurationDefinition->setArgument(0, $config);
 
         if (null === $config['auth_service_id']) {
-            $container->removeDefinition('lopi_pusher.auth_controller');
+            $container->removeDefinition(AuthController::class);
         } else {
-            $controllerDefinition = $container->getDefinition('lopi_pusher.auth_controller');
+            $controllerDefinition = $container->getDefinition(AuthController::class);
             $controllerDefinition->setArgument(1, new Reference($config['auth_service_id']));
         }
 

--- a/src/PusherConfiguration.php
+++ b/src/PusherConfiguration.php
@@ -17,12 +17,12 @@ final class PusherConfiguration
     public function __construct(array $config)
     {
         if (!empty($config['url'])) {
-            $config['app_id'] = substr(parse_url($config['url'], PHP_URL_PATH), 6);
-            $config['key'] = parse_url($config['url'], PHP_URL_USER);
-            $config['secret'] = parse_url($config['url'], PHP_URL_PASS);
-            $config['scheme'] = parse_url($config['url'], PHP_URL_SCHEME);
-            $config['host'] = parse_url($config['url'], PHP_URL_HOST);
-            $config['port'] = parse_url($config['url'], PHP_URL_PORT) ?: $config['port'];
+            $config['app_id'] = substr(parse_url($config['url'], \PHP_URL_PATH), 6);
+            $config['key'] = parse_url($config['url'], \PHP_URL_USER);
+            $config['secret'] = parse_url($config['url'], \PHP_URL_PASS);
+            $config['scheme'] = parse_url($config['url'], \PHP_URL_SCHEME);
+            $config['host'] = parse_url($config['url'], \PHP_URL_HOST);
+            $config['port'] = parse_url($config['url'], \PHP_URL_PORT) ?: $config['port'];
         }
 
         // For backwards compatibility with deprecated host argument

--- a/src/Resources/config/routing.xml
+++ b/src/Resources/config/routing.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="lopi_pusher_bundle_auth" path="/auth" methods="POST">
-        <default key="_controller">Lopi\Bundle\PusherBundle\Controller\AuthController::auth</default>
+        <default key="_controller">Lopi\Bundle\PusherBundle\Controller\AuthController::authAction</default>
     </route>
 
 </routes>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,9 +10,10 @@
             <argument/> <!-- bundle configuration array -->
         </service>
 
-        <service id="lopi_pusher.auth_controller" class="Lopi\Bundle\PusherBundle\Controller\AuthController">
+        <service id="Lopi\Bundle\PusherBundle\Controller\AuthController">
             <argument type="service" id="lopi_pusher.pusher_configuration"/>
             <argument/> <!-- Channel authenticator service implemented by user-->
+            <tag name="controller.service_arguments"/>
         </service>
 
         <service id="lopi_pusher.pusher" class="Pusher\Pusher" public="false">

--- a/tests/IntegrationTests/PusherServiceDefinitionTest.php
+++ b/tests/IntegrationTests/PusherServiceDefinitionTest.php
@@ -24,7 +24,7 @@ final class PusherServiceDefinitionTest extends TestCase
         $prefix = 'lopi_pusher.';
 
         yield [$prefix.'pusher',  Pusher::class, false];
-        yield [$prefix.'auth_controller', AuthController::class, true];
+        yield [AuthController::class, AuthController::class, true];
     }
 
     /**


### PR DESCRIPTION
- AuthController was missing the `controller.service_arguments` tag.
- The route `_controller` was missing the proper function name `authAction`

Since the current configuration isn't working, I've also set the AuthController service to use the FQN without deprecation (id simply didn't work before)