### PR TITLE
Pass ignore SSL option to Guzzle

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('secret')->end()
                 ->scalarNode('cluster')->defaultValue('us-east-1')->end()
                 ->booleanNode('debug')->defaultValue(false)->end()
+                ->booleanNode('verifySSL')->defaultValue(true)->end()
                 ->scalarNode('scheme')->defaultValue('http')->end()
                 ->scalarNode('host')->defaultValue('api.pusherapp.com')->end()
                 ->scalarNode('port')->defaultValue('80')->end()

--- a/src/PusherConfiguration.php
+++ b/src/PusherConfiguration.php
@@ -45,7 +45,13 @@ final class PusherConfiguration
             'timeout' => $config['timeout'],
             'cluster' => $config['cluster'],
             'debug' => $config['debug'],
+            // Configuration for Guzzle:
+            'clientConfig' => [],
         ];
+
+        if (is_bool($config['verifySSL'] ?? null)) {
+            $this->options['clientConfig']['verify'] = $config['verifySSL'];
+        }
 
         if ($encryptionKey = $config['encryption_master_key_base64'] ?? false) {
             $this->options['encryption_master_key_base64'] = $encryptionKey;
@@ -67,6 +73,9 @@ final class PusherConfiguration
         return $this->appId;
     }
 
+    /**
+     * @phpstan-return array{scheme: string, host: string, port: positive-int, timeout: positive-int, cluster: string, debug: bool, clientConfig: array<mixed>}
+     */
     public function getOptions(): array
     {
         return $this->options;

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -20,15 +20,12 @@ class PusherFactory
      */
     public static function create(PusherConfiguration $configuration): Pusher
     {
-        $client = new Client([
-            'verify' => FALSE,
-        ]);
         return new Pusher(
             $configuration->getAuthKey(),
             $configuration->getSecret(),
             $configuration->getAppId(),
             $configuration->getOptions(),
-            client: $client,
+            new Client($configuration->getOptions()['clientConfig']),
         );
     }
 }

--- a/src/PusherFactory.php
+++ b/src/PusherFactory.php
@@ -7,6 +7,7 @@
 
 namespace Lopi\Bundle\PusherBundle;
 
+use GuzzleHttp\Client;
 use Pusher\Pusher;
 
 /**
@@ -19,11 +20,15 @@ class PusherFactory
      */
     public static function create(PusherConfiguration $configuration): Pusher
     {
+        $client = new Client([
+            'verify' => FALSE,
+        ]);
         return new Pusher(
             $configuration->getAuthKey(),
             $configuration->getSecret(),
             $configuration->getAppId(),
-            $configuration->getOptions()
+            $configuration->getOptions(),
+            client: $client,
         );
     }
 }


### PR DESCRIPTION
Conditionally opt into customising Guzzle client, specifically allowing configurations to opt out of SSL certificate validation per https://docs.guzzlephp.org/en/stable/request-options.html#verify

For example when running Soketi with SSL, it seems to force it into only responding via SSL.

When accessed on a private network, the Soketi service may be accessed differently/without SSL/with a different hostname. So it may make sense to ignore whatever cert is returned by Soketi.